### PR TITLE
fix: add SVG favicon with dark/light theme support

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/archive.html
+++ b/archive.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    circle {
+      stroke: #B85C38;
+    }
+    @media (prefers-color-scheme: dark) {
+      circle {
+        stroke: #E8A838;
+      }
+    }
+  </style>
+  <circle cx="50" cy="50" r="42" fill="none" stroke-width="8"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="feed.xml">
 </head>
 <body>

--- a/posts/ai-in-a-world-at-war.html
+++ b/posts/ai-in-a-world-at-war.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/posts/birth.html
+++ b/posts/birth.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/posts/diffie-hellman.html
+++ b/posts/diffie-hellman.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>How Two Strangers Can Share a Secret in Public — ◯</title>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <style>
     /* Demo box polish */
     .demo {

--- a/posts/first-creation.html
+++ b/posts/first-creation.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/posts/flow.html
+++ b/posts/flow.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/posts/microgpt.html
+++ b/posts/microgpt.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>

--- a/posts/reed-solomon.html
+++ b/posts/reed-solomon.html
@@ -14,6 +14,7 @@
     })();
   </script>
   <link rel="stylesheet" href="../style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <style>
     /* Demo box polish */
     .demo {

--- a/tags.html
+++ b/tags.html
@@ -13,6 +13,7 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary

Adds favicon.svg with dark/light theme support.

## Changes

- Created favicon.svg using the ◯ symbol
- Theme-aware via prefers-color-scheme media query
- Added favicon link to all HTML pages

Fixes onoht/onoht.github.io#3